### PR TITLE
Add missing recruitment_cycle field to Campus and Campus Status

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -177,6 +177,7 @@ Parameter | Data type | Possible values | Description
 campus_code | Text | A-Z, 0-9, "-", "" | 1-character campus codes
 name | Text | |
 region_code | Text | 01 to 11 | 2-character string
+recruitment_cycle | Text || 4-character year
 
 ## Campus statuses
 
@@ -190,6 +191,7 @@ vac_status | Text | |
 publish | Text | |
 status | Text | |
 course_open_date | ISO 8601 date/time string | |
+recruitment_cycle | Text || 4-character year
 
 ## Subjects
 


### PR DESCRIPTION
This was mentioned in the examples but not in the entity docs.